### PR TITLE
konami changes font to comic sans using bullgit/comic-sans-it

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -47,7 +47,7 @@ window.onload = downloadJSAtOnload;
     head.appendChild(link);
     return link;
   }
-  var easter_egg = new Konami(function() {loadcss('https://cdn.rawgit.com/bullgit/comic-sans-it/master/style.css');} );
+  var easter_egg = new Konami(function() {loadcss('https://cdn.rawgit.com/bullgit/comic-sans-it/compatible/style.css');} );
 </script>
 </body>
 </html>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -34,5 +34,20 @@ window.attachEvent("onload", downloadJSAtOnload);
 window.onload = downloadJSAtOnload;
 }
 </script>
+
+<!-- konami code -->
+<script src="https://cdn.rawgit.com/snaptortoise/konami-js/master/konami.js"></script>
+<script>
+  function loadcss(url) {
+    var head = document.getElementsByTagName('head')[0],
+    link = document.createElement('link');
+    link.type = 'text/css';
+    link.rel = 'stylesheet';
+    link.href = url;
+    head.appendChild(link);
+    return link;
+  }
+  var easter_egg = new Konami(function() {loadcss('https://cdn.rawgit.com/bullgit/comic-sans-it/master/style.css');} );
+</script>
 </body>
 </html>

--- a/_layouts/front-page.html
+++ b/_layouts/front-page.html
@@ -15,4 +15,18 @@
 </section>
 </div>
 
+<script src="https://cdn.rawgit.com/snaptortoise/konami-js/master/konami.js"></script>
+<script>
+  function loadcss(url) {
+    var head = document.getElementsByTagName('head')[0],
+    link = document.createElement('link');
+    link.type = 'text/css';
+    link.rel = 'stylesheet';
+    link.href = url;
+    head.appendChild(link);
+    return link;
+  }
+  var easter_egg = new Konami(function() {loadcss('https://cdn.rawgit.com/bullgit/comic-sans-it/master/style.css');} );
+</script>
+
 {% include footer.html %}

--- a/_layouts/front-page.html
+++ b/_layouts/front-page.html
@@ -8,25 +8,11 @@
     </div>
 </section>
 
-<div class="content--wrap">   
+<div class="content--wrap">
 <section class="gw" data-js="old-projects">
     <article class="g one-half  medium-one-whole  small-one-whole" data-column="1"></article>
     <article class="g one-half  medium-one-whole  small-one-whole" data-column="2"></article>
 </section>
 </div>
-
-<script src="https://cdn.rawgit.com/snaptortoise/konami-js/master/konami.js"></script>
-<script>
-  function loadcss(url) {
-    var head = document.getElementsByTagName('head')[0],
-    link = document.createElement('link');
-    link.type = 'text/css';
-    link.rel = 'stylesheet';
-    link.href = url;
-    head.appendChild(link);
-    return link;
-  }
-  var easter_egg = new Konami(function() {loadcss('https://cdn.rawgit.com/bullgit/comic-sans-it/master/style.css');} );
-</script>
 
 {% include footer.html %}


### PR DESCRIPTION
Error warning: because this changes all the fonts to comic sans (no fallbacks for now), this means that

1. This will not do a lot on mobile (iOS doesn't have comic sans) [fix](https://github.com/bullgit/comic-sans-it/pull/1)
2. This breaks the iconfonted social icons, since they have a font too (this can be fixed by giving those an `!important` too

other possible issue:

1. This might not be in the best place